### PR TITLE
Add 5 minute timeout to cronjob

### DIFF
--- a/gradescopeCronJob/cronjob
+++ b/gradescopeCronJob/cronjob
@@ -1,1 +1,1 @@
-0 */1 * * * /usr/local/bin/python3 /gradescopeCronJob/gradescope_to_spreadsheet.py
+0 */1 * * * timeout 300 /usr/local/bin/python3 /gradescopeCronJob/gradescope_to_spreadsheet.py


### PR DESCRIPTION
### Jira Ticket

<!-- Replace the field marked <ticket-id> with your ticket id -->
[Jira Ticket](https://dashbd.atlassian.net/jira/software/projects/GS/boards/1?selectedIssue=GS-122)

### Description

Cron job stops automatically after 5 minutes. 

### Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Changes

AFter 5 minutes, the cron job will automatically be killed. The cron job once at the top of the hour (:00). If we change the configurations for this, if we change this to every 2 minutes, the cron job should be killed after 90 seconds for example. The cron job takes 80 seconds to run on my local computer.


### Testing
![image](https://github.com/user-attachments/assets/8879a631-33f9-4530-885a-b292b1dc9674)

Locally tested.

### Checklist

- [x] My branch name matches the format: `<ticket-id>/<brief-description-of-change>`
- [x] My PR name matches the format: `[<ticket-id>] <brief-description-of-change>`
- [x] I have added doc-comments to all new functions ([JSDoc](https://jsdoc.app/) for JS and [Docstrings](https://peps.python.org/pep-0257/) for Python)
- [x] I have reviewed all of my code
- [x] My code only contains major changes related to my ticket

### Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

### Additional Notes

<!-- Any additional information or context relevant to this PR. -->
