### PR TITLE
sys-4/deploy-sp25-gradescope-manually

### DIFF
--- a/gradescopeCronJob/config/cs10_fa24_test.json
+++ b/gradescopeCronJob/config/cs10_fa24_test.json
@@ -1,0 +1,9 @@
+{
+  "GRADESCOPE_COURSE_ID": "831412",
+  "SCOPES": ["https://www.googleapis.com/auth/spreadsheets"],
+  "SPREADSHEET_ID": "1B4DQNbzo8OD6Mx9UB-AHeBz8f13ZdylXlnIs1KAbZIk",
+  "NUMBER_OF_STUDENTS": 192,
+  "PL_COURSE_ID": 164327,
+  "INCLUDE_PYTURIS": true,
+  "PYTURIS_ASSIGNMENT_ID": 2452829
+}

--- a/gradescopeCronJob/config/cs10_sp25_test.json
+++ b/gradescopeCronJob/config/cs10_sp25_test.json
@@ -1,0 +1,9 @@
+{
+  "GRADESCOPE_COURSE_ID": "957259",
+  "SCOPES": ["https://www.googleapis.com/auth/spreadsheets"],
+  "SPREADSHEET_ID": "1ah8_Pyec_VCGo26a-91eWnhJFKAEmEKr8zvZsn5DZp0",
+  "NUMBER_OF_STUDENTS": 70,
+  "PL_COURSE_ID": "177790",
+  "INCLUDE_PYTURIS": false,
+  "PYTURIS_ASSIGNMENT_ID": 2509767
+}

--- a/gradescopeCronJob/gradescope_to_spreadsheet_cs10_sp25.py
+++ b/gradescopeCronJob/gradescope_to_spreadsheet_cs10_sp25.py
@@ -35,7 +35,7 @@ logging.basicConfig(
     level=logging.INFO,  # or DEBUG for more detail
     format="%(asctime)s - %(levelname)s - %(message)s",
     handlers=[
-        # logging.FileHandler("/var/log/cron.log"),  # Logs to file, comment out line for local testing ONLY
+        logging.FileHandler("/var/log/cron.log"),  # Logs to file, comment out line for local testing ONLY
         logging.StreamHandler(sys.stdout)  # Logs to console (stdout)
     ]
 )

--- a/gradescopeCronJob/gradescope_to_spreadsheet_cs10_sp25.py
+++ b/gradescopeCronJob/gradescope_to_spreadsheet_cs10_sp25.py
@@ -46,7 +46,7 @@ logger.info("Starting the gradescope_to_spreadsheet script.")
 # Load JSON variables
 # Note: this class JSON name can be made customizable, inputted through a front end user interface for example
 # But the default is cs10_fall2024.json
-class_json_name = 'cs10_fall2024.json'
+class_json_name = 'cs10_sp2025.json'
 config_path = os.path.join(os.path.dirname(__file__), 'config/', class_json_name)
 with open(config_path, "r") as config_file:
     config = json.load(config_file)


### PR DESCRIPTION
…to the gradescope instance issue that the GradeScope API endpoint is different

### Jira Ticket

<!-- Replace the field marked <ticket-id> with your ticket id -->
[Jira Ticket](https://dashbd.atlassian.net/browse/<ticket-id>)

### Description
Added new configuration files and created a sp25 script version, due to the GradeScoped Script API endpoint returning a different result for the fall 2024 configuration and the spring 2025 configuration.

The fall 2024 gradescope instance retrieved the first name and last name in the same columns, while the spring 2025 instance retrieved the first and last name in different columns. This resulted in the breaking change, which is why we've developed this new functionality.

This also modifies the cloud deployment process slightly.

The new feature is the SP 25 customized script with the updated google sheets parsing formula.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would change existing functionality)

### Changes

Here is the updated formula: 
# Formula for Spring 2025 GradeScope Instance
GRADE_RETRIEVAL_SPREADSHEET_FORMULA = '=XLOOKUP(C:C, INDIRECT( INDIRECT(ADDRESS(1, COLUMN(), 4)) & "!C:C"), INDIRECT(INDIRECT(ADDRESS(1, COLUMN(), 4)) & "!F:F"))'
DISCUSSION_COMPLETION_INDICATOR_FORMULA = '=IF(XLOOKUP($C:$C, INDIRECT(INDIRECT(ADDRESS(1,COLUMN(),4)) & "!C:C"), INDIRECT(INDIRECT(ADDRESS(1,COLUMN(),4)) & "!H:H")) = "Missing", 0, 1)'


### Testing

Created a CS 10 SP 25 test instance:
cs10_sp25_test.json

Tested on google sheet, and actually manually ran script on production.

### Checklist

- [x] My branch name matches the format: `<ticket-id>/<brief-description-of-change>`
- [x] My PR name matches the format: `[<ticket-id>] <brief-description-of-change>`
- [x] I have added doc-comments to all new functions ([JSDoc](https://jsdoc.app/) for JS and [Docstrings](https://peps.python.org/pep-0257/) for Python)
- [x] I have reviewed all of my code
- [x] My code only contains major changes related to my ticket

### Screenshots/Video


### Additional Notes

<!-- Any additional information or context relevant to this PR. -->
